### PR TITLE
update msw peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   },
   "peerDependencies": {
     "headers-utils": "^3.0.2",
-    "msw": "^0.33.0"
+    "msw": ">=0.33.0"
   }
 }


### PR DESCRIPTION
to avoid errors like:
```
Could not resolve dependency:
npm ERR! peer msw@"^0.33.0" from @mswjs/http-middleware@0.1.1
``` 