### PR TITLE
fix: use "onMockedResponse" hooks vs "onMockedResponseSent" (msw@0.47.1 compatibility)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,7 +44,7 @@ export function createMiddleware(
            */
           baseUrl: serverOrigin,
         },
-        onMockedResponseSent(mockedResponse) {
+        onMockedResponse(mockedResponse) {
           const { status, statusText, headers, body } = mockedResponse
 
           res.statusCode = status


### PR DESCRIPTION
After [this](https://github.com/mswjs/msw/pull/1392) PR, the `onMockedResponseSent` hook no longer exists. Let's use the hook that _does_ exist.