### PR TITLE
fix: headers without browser polyfill

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,7 +28,7 @@ export function createMiddleware(
       new URL(req.url, serverOrigin),
       {
         method: req.method,
-        headers: new Headers(req.headers as HeadersInit),
+        headers: req.headers as HeadersInit,
         credentials: 'omit',
         // Request with GET/HEAD method cannot have body.
         body: ['GET', 'HEAD'].includes(method)


### PR DESCRIPTION
When running it inside a project I got the following bug/TypeError
```
66 |         this._names = new Map();
67 |         /**
68 |          * @note Cannot check if the `init` is an instance of the `Headers`
69 |          * because that class is only defined in the browser.
70 |          */
71 |         if (['Headers', 'HeadersPolyfill'].includes(init === null || init === void 0 ? void 0 : init.constructor.name) ||
                                                                                                    ^
TypeError: undefined is not an object (evaluating 'init.constructor.name')
      at new HeadersPolyfill (/Users/stijnvanhulle/GitHub/kubb/node_modules/.pnpm/headers-polyfill@3.0.4/node_modules/headers-polyfill/lib/Headers.js:71:96)
```

Replacing `headers: new headers_polyfill_1.Headers(req.headers),` by `headers: req.headers` fixed the issue. 

I'm not completely sure why that is happening.