### PR TITLE
feat: gracefully handle middleware exceptions

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -76,6 +76,6 @@ export function createMiddleware(
           next()
         },
       },
-    )
+    ).catch(next)
   }
 }

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -15,6 +15,10 @@ const httpServer = new HttpServer((app) => {
         return new HttpResponse(null, { status: 204 })
       }),
 
+      http.get('/error', () => {
+        throw new Error('Something went wrong.')
+      }),
+
       http.get('/user', () => {
         return HttpResponse.json(
           { firstName: 'John' },
@@ -70,4 +74,11 @@ it('returns the original response given no matching request handler', async () =
   const text = await res.text()
 
   expect(text).toEqual('book')
+})
+
+it('forwards promise rejections to error middleware', async () => {
+  const res = await fetch(httpServer.http.url('/error'))
+
+  expect(res.status).toEqual(500)
+  expect(res.ok).toBeFalsy()
 })


### PR DESCRIPTION
This PR prevents HTTP servers from crashing when they use this middleware and an error is thrown in some MSW handler. Now, the error can be handled by the server's error middleware instead.

Background:
We have a test setup with MSW handlers that use `@mswjs/data` and query the DB with strict queries. Therefore, it may happen that a handler throws an error. Yesterday, we started to this package to reuse our handlers and DB setup for local development as well.

We noticed that the whole server process crashes when `@mswjs/data` throws an error instead of handling it with the default error middleware built into Express. This happens because Express is not able to handle Promises, yet. Apparently, it is only able to catch errors in synchronous code automatically. Promise rejections have to be passed to the `next` argument explicitly. See: https://expressjs.com/en/guide/error-handling.html